### PR TITLE
Fix root password check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -132,7 +132,7 @@
     - rule_5.4.2.4
   block:
     - name: "Ensure root password is set"
-      ansible.builtin.shell: passwd -S root | egrep -e "(Password set, SHA512 crypt|Password locked)"
+      ansible.builtin.shell: grep '^root:' /etc/shadow | grep -qE '^\S+:\$y\$|^\S+:\$6\$|^\S+:!\$|^\S+:\*'
       changed_when: false
       register: prelim_root_passwd_set
 


### PR DESCRIPTION
**Overall Review of Changes:**
Check of root password (if it's set or locked) does not work anymore as output of `passwd -S` has changed. The proposed solution does the same thing and it also pass if Yescrypt is used.

**Issue Fixes:**
N/A

**Enhancements:**
N/A

**How has this been tested?:**
Tested on Alma linux 10

