### PR TITLE
Fixing /boot/efi mount issue

### DIFF
--- a/tasks/section_1/cis_1.4.x.yml
+++ b/tasks/section_1/cis_1.4.x.yml
@@ -56,7 +56,7 @@
         - name: "1.4.2 | PATCH | Ensure permissions on bootloader config are configured | efi based system | Build Options"
           when: item not in discovered_efi_fstab.stdout
           ansible.builtin.set_fact:
-            efi_mount_opts_addition: "{{ efi_mount_opts_addition + item + ',' }}"
+            efi_mount_opts_addition: "{{ efi_mount_opts_addition + ',' + item }}"
           loop: "{{ efi_mount_options }}"
 
         - name: "1.4.2 | PATCH | Ensure permissions on bootloader config are configured | efi based system | Add mount options"


### PR DESCRIPTION
**Overall Review of Changes:**
With CIS 1.4.2  control /boot/efi mount is not usable any more as you can see below. So fixing that by moving ',' in middle of mount options instead of ending.
<img width="1023" height="74" alt="Screenshot 2025-08-22 at 10 50 21 AM" src="https://github.com/user-attachments/assets/07bbbaf5-f724-4caa-9ad9-adb0f28ae704" />

with the fix /boot/efi line item would change from 
UUID=43E3-950A /boot/efi vfat defaults,umask=0077,shortname=winntfmask=0077,uid=0,gid=0, 0 0
to 
UUID=43E3-950A /boot/efi vfat defaults,umask=0077,shortname=winnt,fmask=0077,uid=0,gid=0 0 0

Reference: RHEL 9 CIS for the same control
https://github.com/ansible-lockdown/RHEL9-CIS/
<img width="1124" height="114" alt="Screenshot 2025-08-22 at 10 44 45 AM" src="https://github.com/user-attachments/assets/33fa6ce3-dd80-4e1e-94b2-5a9b0cae88a9" />
blob/39c7dfa18720ba007f2fc56ab723e163751b0755/tasks/section_1/cis_1.4.x.yml#L60


**Issue Fixes:**
Please list (using linking) any open issues this PR addresses
Fixing /boot/efi mount issue

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A
Tested with simple playbook containing only this CIS 1.4.2 control and working fine as expected.

<im
<img width="966" height="538" alt="Screenshot 2025-08-22 at 10 48 15 AM" src="https://github.com/user-attachments/assets/4ba0a1cc-fb9e-4ebf-a7e6-5299d6fd3308" />
g width="1025" height="75" alt="Screenshot 2025-08-22 at 10 45 58 AM" src="https://github.com/user-attachments/assets/55ffd01f-39fd-439f-8ad3-9f3fc865bbef" />



