### PR TITLE
Update cis_1.1.1.x.yml

### DIFF
--- a/tasks/section_1/cis_1.1.1.x.yml
+++ b/tasks/section_1/cis_1.1.1.x.yml
@@ -275,7 +275,7 @@
         mode: 'u+x,go-wx'
 
     - name: "1.1.1.9 | AUDIT | Ensure unused filesystems kernel modules are not available | Run discovery script"
-      ansible.builtin.command: /var/fs_with_cves.sh
+      ansible.builtin.command: /bin/sh /var/fs_with_cves.sh
       changed_when: false
       failed_when: discovered_fs_modules_loaded.rc not in [ 0, 99 ]
       register: discovered_fs_modules_loaded


### PR DESCRIPTION
Fix selinux issue in running 1.1.1.9 /var/fs_with_cves.sh, and getting "permission denied" when role is applied to packer-iso based os
---


i build OL10 with packer on vmware from iso. after OS boots i apply ansible roles to get golden image after all.
so, on clean ol10, installed from iso i get "permission denied" when we try to run this script. and it's all about selinux.