### PR TITLE
Fix 5.4.1.2: use password_expire_min for minimum password days

### DIFF
--- a/tasks/section_5/cis_5.4.1.x.yml
+++ b/tasks/section_5/cis_5.4.1.x.yml
@@ -66,7 +66,7 @@
         - rhel10cis_force_user_mindays
       ansible.builtin.user:
         name: "{{ item }}"
-        password_expire_max: "{{ rhel10cis_pass_min_days }}"
+        password_expire_min: "{{ rhel10cis_pass_min_days }}"
       loop: "{{ discovered_min_days.stdout_lines }}"
 
 - name: "5.4.1.3 | PATCH | Ensure password expiration warning days is configured"


### PR DESCRIPTION
5.4.1.2 remediates minimum password age but currently sets password_expire_max. This switches to password_expire_min.