### PR TITLE
Fix 5.4.1.3: use rhel10cis_pass_warn_age in chage command

### DIFF
--- a/tasks/section_5/cis_5.4.1.x.yml
+++ b/tasks/section_5/cis_5.4.1.x.yml
@@ -96,7 +96,7 @@
         - discovered_warn_days.stdout_lines | length > 0
         - item in prelim_interactive_users | map(attribute='username') | list
         - rhel10cis_force_user_warnage
-      ansible.builtin.command: "chage --warndays {{ rhel10cis_pass['warn_age'] }} {{ item }}"
+      ansible.builtin.command: "chage --warndays {{ rhel10cis_pass_warn_age }} {{ item }}"
       changed_when: true
       loop: "{{ discovered_warn_days.stdout_lines }}"
 


### PR DESCRIPTION
Fix variable reference in 5.4.1.3 remediation by using the defined variable rhel10cis_pass_warn_age.