### PR TITLE
Fix 5.4.1.5 remediation for empty and zero inactive values

### DIFF
--- a/tasks/section_5/cis_5.4.1.x.yml
+++ b/tasks/section_5/cis_5.4.1.x.yml
@@ -138,7 +138,7 @@
       changed_when: true
 
     - name: "5.4.1.5 | AUDIT | Ensure inactive password lock is configured | Getting user list"
-      ansible.builtin.shell: "awk -F: '($2~/^\\$.+\\$/) {if($7 > {{ rhel10cis_inactive_lock_days }} || $7 < 0)print $1}' /etc/shadow" # noqa yaml[colons]
+      ansible.builtin.shell: "awk -F: '($2~/^\\$.+\\$/) {if($7 < 1 || $7 > {{ rhel10cis_inactive_lock_days }})print $1}' /etc/shadow" # noqa yaml[colons]
       changed_when: false
       check_mode: false
       register: discovered_passwdlck_user_list


### PR DESCRIPTION
Include empty and zero inactive-day values in user selection so remediation aligns with the audit expectation.