### PR TITLE
Fix 1.2.1.3 regex typo for repo_gpgcheck replacement

### DIFF
--- a/tasks/section_1/cis_1.2.1.x.yml
+++ b/tasks/section_1/cis_1.2.1.x.yml
@@ -80,7 +80,7 @@
     - name: "1.2.1.3 | PATCH | Ensure repo_gpgcheck is globally activated | amend repo files"
       ansible.builtin.replace:
         path: "{{ item.path }}"
-        regexp: ^repo_gpgcheck\s*=s*0
+        regexp: ^repo_gpgcheck\s*=\s*0
         replace: repo_gpgcheck=1
       loop: "{{ discovered_repo_files.files }}"
       loop_control:


### PR DESCRIPTION
Correct regex typo in repo_gpgcheck replacement so repo files with repo_gpgcheck=0 are properly updated.