### PR TITLE
Fix 1.5.1: add missing '*' before hard core 0

### DIFF
--- a/templates/etc/security/limits.d/60-limits.conf.j2
+++ b/templates/etc/security/limits.d/60-limits.conf.j2
@@ -1,4 +1,4 @@
 {{ file_managed_by_ansible }}
 
 # Control 1.5.1
-hard core 0
+* hard core 0


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
The `hard `entry in the limits template was missing the `*` at the start. That makes the line invalid, so the system ignores the rule.

**Issue Fixes:**
N/A

**Enhancements:**
N/A (bugfix)

**How has this been tested?:**
Tested on a RHEL 10 system: after deploying the rendered file, no invalid rule warnings are shown anymore

