### PR TITLE
Fix 6.3.3.33 & 6.3.3.34: add missing space for two kernel module audit rules

### DIFF
--- a/templates/etc/audit/rules.d/50-kernel_modules.rules.j2
+++ b/templates/etc/audit/rules.d/50-kernel_modules.rules.j2
@@ -10,8 +10,8 @@
 -a always,exit -F arch=b64 -S {{ arch_syscalls|join(',') }} -F auid>={{ prelim_min_int_uid }} -F auid!=unset -k kernel_modules
 {% endif %}
 {% if rhel10cis_rule_6_3_3_33 %}
--a always,exit -F arch=b64 -S delete_module -F auid>={{ prelim_min_int_uid }}-F auid!=unset -k kernel_modules
+-a always,exit -F arch=b64 -S delete_module -F auid>={{ prelim_min_int_uid }} -F auid!=unset -k kernel_modules
 {% endif %}
 {% if rhel10cis_rule_6_3_3_34 %}
--a always,exit -F arch=b64 -S query_module -F auid>={{ prelim_min_int_uid }}-F auid!=unset -k kernel_modules
+-a always,exit -F arch=b64 -S query_module -F auid>={{ prelim_min_int_uid }} -F auid!=unset -k kernel_modules
 {% endif %}


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
Fixes a formatting issue in `50-kernel_modules.rules.j2`. The last two rules (`delete_module` and `query_module`) were missing a space after `auid>={{ prelim_min_int_uid }}`, which makes the rule line invalid. This adds the missing space so auditd parses the rules correctly.

**Issue Fixes:**
N/A

**Enhancements:**
N/A (bugfix)

**How has this been tested?:**
Tested on RHEL 10: auditd now loads the rules without errors.

