### PR TITLE
Added missing tags for required prelim task on control 7.2.8 when run…

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -313,6 +313,9 @@
 
 - name: "PRELIM | PATCH | Install ACL if 7.2.8"
   when: rhel10cis_rule_7_2_8
+  tags:
+    - level1-server
+    - level1-workstation
   ansible.builtin.package:
     name: acl
     state: present


### PR DESCRIPTION
**Overall Review of Changes:**
Added tags to the ACL installation prelim task on target hosts. This is required for the dependency of control 7.2.8. Previously, when running the playbook with the tags level1-workstation or level1-server, the preliminary task was skipped because it did not have any tags assigned. As a result, the ACL installation step was not executed during tagged runs, and the task 7.2.8 fails at the same time. 

**Enhancements:**
Improves playbook behavior when executed with tag filtering by ensuring prerequisite tasks are included.

**How has this been tested?:**
Manually on RHEL 10 Machines 
