### PR TITLE
Corrected task 3.2.3 to Level 1-Server and Workstation

### DIFF
--- a/tasks/section_3/cis_3.2.x.yml
+++ b/tasks/section_3/cis_3.2.x.yml
@@ -63,8 +63,8 @@
 - name: "3.2.3 | PATCH | Ensure dccp kernel module is not available"
   when: rhel10cis_rule_3_2_3
   tags:
-    - level2-server
-    - level2-workstation
+    - level1-server
+    - level1-workstation
     - patch
     - rule_3.2.3
     - dccp


### PR DESCRIPTION
**Overall Review of Changes:**
Corrected task 3.2.3 to Level 1- Server and Level1-Workstation according to official CIS documentation.

**How has this been tested?:**
Ran the playbook with tags to enforce Level 1 enforcement on target machines and audited it using Goss and saw non compliance on this task. 

