### PR TITLE
fix: remove stray bracket in aide.cron.j2 Jinja2 template

### DIFF
--- a/templates/etc/cron.d/aide.cron.j2
+++ b/templates/etc/cron.d/aide.cron.j2
@@ -3,4 +3,4 @@
 # Run AIDE integrity check
 # CIS 1.3.2
 
-{{ rhel10cis_aide_cron_minute }} {{ rhel10cis_aide_cron_hour }} {{ rhel10cis_aide_cron_month }} {{ rhel10cis_aide_cron_weekday }} {{ rhel10cis_aide_cron_job] }}
+{{ rhel10cis_aide_cron_minute }} {{ rhel10cis_aide_cron_hour }} {{ rhel10cis_aide_cron_month }} {{ rhel10cis_aide_cron_weekday }} {{ rhel10cis_aide_cron_job }}


### PR DESCRIPTION
## Summary

`templates/etc/cron.d/aide.cron.j2` contains a stray `]` before `}}`:

```
{{ rhel10cis_aide_cron_job] }}
```

Jinja2 raises a `TemplateSyntaxError` at render time. AIDE is currently disabled by default (`rhel10cis_rule_6_1_2: false`), but enabling it causes the entire playbook to fail at this template.

## Fix

Remove the stray `]`: `{{ rhel10cis_aide_cron_job] }}` → `{{ rhel10cis_aide_cron_job }}`