### PR TITLE
fix: remove trailing dot causing invalid YAML in goss vars template

### DIFF
--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -100,7 +100,7 @@ rhel10cis_rule_1_2_1_1: {{ rhel10cis_rule_1_2_1_1 }}
 rhel10cis_rule_1_2_1_2: {{ rhel10cis_rule_1_2_1_2 }}
 rhel10cis_rule_1_2_1_3: {{ rhel10cis_rule_1_2_1_3 }}
 rhel10cis_rule_1_2_1_4: {{ rhel10cis_rule_1_2_1_4 }}
-rhel10cis_rule_1_2_1_5: {{ rhel10cis_rule_1_2_1_5 }}. ## New
+rhel10cis_rule_1_2_1_5: {{ rhel10cis_rule_1_2_1_5 }} # New
 # Package updates
 rhel10cis_rule_1_2_2_1: {{ rhel10cis_rule_1_2_2_1 }}
 


### PR DESCRIPTION
## Summary

`templates/ansible_vars_goss.yml.j2` line 103:

```
rhel10cis_rule_1_2_1_5: {{ rhel10cis_rule_1_2_1_5 }}. ## New
```

This renders as `rhel10cis_rule_1_2_1_5: true.` which is not valid YAML. Goss will fail to parse the vars file if `run_audit` is enabled. The `## New` is also not a valid YAML inline comment.

## Fix

`{{ rhel10cis_rule_1_2_1_5 }}. ## New` → `{{ rhel10cis_rule_1_2_1_5 }} # New`