### PR TITLE
add option to whitelist /var/log files from permission changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1439,6 +1439,10 @@ rhel10cis_rsyslog_logrotate_create: true
 # Uncomment and add the required options e.g. mode owner group
 # rhel10cis_rsyslog_logrotate_create_opts:
 
+# Control 6.2.4.1 allowing exceptions for /var/log permissions
+# This can be used to whitelist log files from permission changes, regex format
+rhel10cis_logpermissions_whitelist: []
+
 ##  Control 6.3.1.3 - Ensure audit_backlog_limit is sufficient
 # This variable represents the audit backlog limit, i.e., the maximum number of audit records that the
 # system can buffer in memory, if the audit subsystem is unable to process them in real-time.

--- a/tasks/section_6/cis_6.2.4.1.yml
+++ b/tasks/section_6/cis_6.2.4.1.yml
@@ -17,6 +17,23 @@
       failed_when: false
       register: discovered_logfiles
 
+    - name: "6.2.4.1 | AUDIT | Ensure access to all logfiles has been configured | get log files matching whitelist regex entries"
+      when:
+        - discovered_logfiles.stdout_lines | length > 0
+        - rhel10cis_logpermissions_whitelist | length > 0
+        - item.0 | regex_search(item.1)
+      ansible.builtin.set_fact:
+        logfiles_whitelist: "{{ (logfiles_whitelist | default([])) + [item.0] }}"
+      loop: "{{ discovered_logfiles.stdout_lines | product(rhel10cis_logpermissions_whitelist) | list }}"
+      loop_control:
+        label: "{{ item.0 }} with regex {{ item.1 }}"
+
+    - name: "6.2.4.1 | AUDIT | Ensure access to all logfiles has been configured | generate todo list by dropping whitelist matches from findings"
+      when:
+        - discovered_logfiles.stdout_lines | length > 0
+      ansible.builtin.set_fact:
+        logfiles_todo: "{{ discovered_logfiles.stdout_lines | difference(logfiles_whitelist | default([])) }}"
+
     - name: "6.2.4.1 | PATCH | Ensure access to all logfiles has been configured | change permissions SSSD min 660"
       when:
         - discovered_logfiles.stdout_lines | length > 0
@@ -26,7 +43,7 @@
         mode: 'ug-x,o-rwx'
       failed_when: discovered_logfile_sssd_list.state not in '[ file, absent ]'
       register: discovered_logfile_sssd_list
-      loop: "{{ discovered_logfiles.stdout_lines }}"
+      loop: "{{ logfiles_todo }}"
 
     - name: "6.2.4.1 | PATCH | Ensure access to all logfiles has been configured | change permissions tmp min 664"
       when:
@@ -37,7 +54,7 @@
         mode: 'ug-x,o-wx'
       failed_when: discovered_logfile_tmp_list.state not in '[ file, absent ]'
       register: discovered_logfile_tmp_list
-      loop: "{{ discovered_logfiles.stdout_lines }}"
+      loop: "{{ logfiles_todo }}"
 
     - name: "6.2.4.1 | PATCH | Ensure access to all logfiles has been configured | change permissions else all 640"
       when:
@@ -48,4 +65,6 @@
         mode: 'u-x,g-wx,o-rwx'
       failed_when: discovered_logfile_else_list.state not in '[ file, absent ]'
       register: discovered_logfile_else_list
-      loop: "{{ discovered_logfiles.stdout_lines }}"
+      loop: "{{ logfiles_todo }}"
+
+...

--- a/tasks/section_6/cis_6.2.4.1.yml
+++ b/tasks/section_6/cis_6.2.4.1.yml
@@ -21,7 +21,7 @@
       when:
         - discovered_logfiles.stdout_lines | length > 0
         - rhel10cis_logpermissions_whitelist | length > 0
-        - item.0 | regex_search(item.1)
+        - (item.0 | regex_search(item.1)) is not none
       ansible.builtin.set_fact:
         logfiles_whitelist: "{{ (logfiles_whitelist | default([])) + [item.0] }}"
       loop: "{{ discovered_logfiles.stdout_lines | product(rhel10cis_logpermissions_whitelist) | list }}"


### PR DESCRIPTION
Signed-off-by: Xaver Amberger (skullbringer) <xaver95amberger@aol.com>

Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
RFE / new feature: add option to whitelist /var/log files from permission changes
In our environment multiple users must be able to write/delete certain application log file data, hence requiring this feature

**Issue Fixes:**
N/A

**Enhancements:**
- adds an optional variable rhel10cis_logpermissions_whitelist to exclude log files from permission changes (section 6.2.4.1)
- creates a new variable/fact logfiles_whitelist at runtime from discovered_logfiles.stdout_lines elements matching rhel10cis_logpermissions_whitelist
- whitelist checking works in a single loop without further include_tasks by creating a product of the two lists and comparing each product's two elements
- then creates logfiles_todo from the difference of logfiles_whitelist and discovered_logfiles.stdout_lines, for use in subsequent tasks 

**How has this been tested?:**
- empty list rhel10cis_logpermissions_whitelist (default)
- one or more regex elements in rhel10cis_logpermissions_whitelist 
- empty discovered_logfiles.stdout_lines by intentionally breaking find command