### PR TITLE
fix: remove stray bracket in aide.cron.j2 Jinja2 template

### DIFF
--- a/templates/etc/cron.d/aide.cron.j2
+++ b/templates/etc/cron.d/aide.cron.j2
@@ -3,4 +3,4 @@
 # Run AIDE integrity check
 # CIS 1.3.2
 
-{{ rhel10cis_aide_cron_minute }} {{ rhel10cis_aide_cron_hour }} {{ rhel10cis_aide_cron_month }} {{ rhel10cis_aide_cron_weekday }} {{ rhel10cis_aide_cron_job] }}
+{{ rhel10cis_aide_cron_minute }} {{ rhel10cis_aide_cron_hour }} {{ rhel10cis_aide_cron_month }} {{ rhel10cis_aide_cron_weekday }} {{ rhel10cis_aide_cron_job }}


### PR DESCRIPTION
## Summary

The `aide.cron.j2` template contains a stray closing bracket `]` in the Jinja2 variable expression:

```
{{ rhel10cis_aide_cron_job] }}
```

This is invalid Jinja2 syntax and causes a template rendering error. Fix: remove the stray `]`.

```
{{ rhel10cis_aide_cron_job }}
```

Signed-off-by: aaronk1 <aaronk1@users.noreply.github.com>