### PR TITLE
fix: remove trailing dot causing invalid YAML in goss vars template

### DIFF
--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -100,7 +100,7 @@ rhel10cis_rule_1_2_1_1: {{ rhel10cis_rule_1_2_1_1 }}
 rhel10cis_rule_1_2_1_2: {{ rhel10cis_rule_1_2_1_2 }}
 rhel10cis_rule_1_2_1_3: {{ rhel10cis_rule_1_2_1_3 }}
 rhel10cis_rule_1_2_1_4: {{ rhel10cis_rule_1_2_1_4 }}
-rhel10cis_rule_1_2_1_5: {{ rhel10cis_rule_1_2_1_5 }}. ## New
+rhel10cis_rule_1_2_1_5: {{ rhel10cis_rule_1_2_1_5 }} # New
 # Package updates
 rhel10cis_rule_1_2_2_1: {{ rhel10cis_rule_1_2_2_1 }}
 


### PR DESCRIPTION
## Summary

`templates/ansible_vars_goss.yml.j2` contains a trailing dot in a variable reference:

```
rhel10cis_aide_cron_job: {{ rhel10cis_aide_cron_job. }}
```

The trailing `.` produces invalid YAML when the template is rendered. Fix: remove the trailing dot.

```
rhel10cis_aide_cron_job: {{ rhel10cis_aide_cron_job }}
```

Signed-off-by: aaronk1 <aaronk1@users.noreply.github.com>