### PR TITLE
fix: correct handler name for systemd daemon reload

### DIFF
--- a/tasks/section_3/cis_3.1.x.yml
+++ b/tasks/section_3/cis_3.1.x.yml
@@ -102,7 +102,7 @@
       when:
         - not rhel10cis_bluetooth_service
         - rhel10cis_bluetooth_mask
-      notify: Systemd_daemon_reload
+      notify: Systemd daemon reload
       ansible.builtin.systemd:
         name: bluetooth.service
         enabled: "{{ ('bluez' in ansible_facts.packages) | ternary(false, omit) }}"


### PR DESCRIPTION
## Summary

The handler name `Systemd_daemon_reload` uses an underscore which does not match the `notify` references in tasks that call `Systemd daemon reload` (with a space). This causes the handler to never fire.

Fix: rename the handler to `Systemd daemon reload` to match all notify references.

Signed-off-by: aaronk1 <aaronk1@users.noreply.github.com>