### PR TITLE
fix(section_5): replace \h with [ \t] in 5.3.2.3.3 lineinfile regexp

### DIFF
--- a/tasks/section_5/cis_5.3.2.3.x.yml
+++ b/tasks/section_5/cis_5.3.2.3.x.yml
@@ -94,7 +94,7 @@
         - rhel10cis_disruption_high
       ansible.builtin.lineinfile:
         path: "/{{ item }}"
-        regexp: ^(password\h+[^#\n\r]+\h+pam_pwhistory\.so\h+)(.*)(use_authtok)
+        regexp: ^(password[ \t]+[^#\n\r]+[ \t]+pam_pwhistory\.so[ \t]+)(.*)(use_authtok)
         line: "\\1\\2 use_authtok"
         backrefs: true
       loop:


### PR DESCRIPTION
## Summary

`ansible.builtin.lineinfile` uses Python's `re` module, which does not support the `\h` POSIX horizontal whitespace shorthand. This causes a `bad escape \h at position 10` error at runtime when rule 5.3.2.3.3 runs with `rhel10cis_disruption_high: true` and `rhel10cis_allow_authselect_updates: false`.

The `grep -P` calls in the audit tasks are unaffected — Perl regex handles `\h` natively.

## Change

Replace the three `\h` occurrences in the `lineinfile` regexp with the equivalent character class `[ \t]`:

```yaml
# Before
regexp: ^(password\h+[^#\n\r]+\h+pam_pwhistory\.so\h+)(.*)(use_authtok)

# After
regexp: ^(password[ \t]+[^#\n\r]+[ \t]+pam_pwhistory\.so[ \t]+)(.*)(use_authtok)
```

## Test

Validated in check mode against OL10.1 — task runs cleanly with no regex error.