### PR TITLE
fix(section_3): add missing blacklist.conf entry for tipc module (3.2.4)

### DIFF
--- a/tasks/section_3/cis_3.2.x.yml
+++ b/tasks/section_3/cis_3.2.x.yml
@@ -80,6 +80,21 @@
     - install tipc /bin/true
     - blacklist tipc
 
+- name: "3.2.4 | PATCH | Ensure tipc kernel module is not available | blacklist"
+  when: rhel10cis_rule_3_2_4
+  tags:
+    - level1-server
+    - level1-workstation
+    - patch
+    - rule_3.2.4
+    - tipc
+  ansible.builtin.lineinfile:
+    path: /etc/modprobe.d/blacklist.conf
+    regexp: "^(#)?blacklist tipc(\\s|$)"
+    line: "blacklist tipc"
+    mode: 'u-x,go-rwx'
+    create: true
+
 - name: "3.2.5 | PATCH | Ensure rds kernel module is not available"
   when: rhel10cis_rule_3_2_5
   tags:


### PR DESCRIPTION
## Summary

Rule 3.2.4 writes `install tipc /bin/true` and `blacklist tipc` to `/etc/modprobe.d/60-tipc.conf` via a loop, but does not write a `blacklist tipc` entry to `/etc/modprobe.d/blacklist.conf`. The other modules in this section (atm, can, dccp, rds, sctp) also only write to their own `60-X.conf` files, so this adds a dedicated sibling task for tipc to ensure the blacklist entry lands in `blacklist.conf` as the CIS benchmark requires.

## Change

Added a sibling task after the main 3.2.4 task:

```yaml
- name: "3.2.4 | PATCH | Ensure tipc kernel module is not available | blacklist"
  when: rhel10cis_rule_3_2_4
  tags:
    - level1-server
    - level1-workstation
    - patch
    - rule_3.2.4
    - tipc
  ansible.builtin.lineinfile:
    path: /etc/modprobe.d/blacklist.conf
    regexp: "^(#)?blacklist tipc(\\s|$)"
    line: "blacklist tipc"
    mode: 'u-x,go-rwx'
    create: true
```

## Test

Validated in check mode against OL10.1 — task runs cleanly and writes the expected entry to `/etc/modprobe.d/blacklist.conf`.