### PR TITLE
Added loopback firewall zone variable for task 4.1.5 and 4.1.6

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -923,6 +923,10 @@ rhel10cis_active_firewall_zone: public
 # DROP - Will drop all attempts to connect that are not whitelisted
 rhel10cis_firewalld_target: DROP
 
+# Rules 4.1.5 / 4.1.6
+# Zone the loopback interface (lo) is assigned to
+rhel10cis_loopback_firewall_zone: trusted
+
 ## Section 5 vars
 
 ## Section 5.1 - SSH

--- a/tasks/section_4/cis_4.1.x.yml
+++ b/tasks/section_4/cis_4.1.x.yml
@@ -122,7 +122,7 @@
     - name: "4.1.5 | PATCH | Ensure firewalld loopback traffic is configured | if loopback - no-zone"
       when: "'no zone' in discovered_loopback_zone.stderr"
       ansible.posix.firewalld:
-        zone: trusted
+        zone: "{{ rhel10cis_loopback_firewall_zone }}"
         permanent: true
         state: enabled
         interface: lo
@@ -131,7 +131,7 @@
     - name: "4.1.5 | PATCH | Ensure firewalld loopback traffic is configured | if loopback - no-zone"
       when: "'ACCEPT' not in discovered_loopback_zone.stdout"
       ansible.posix.firewalld:
-        zone: trusted
+        zone: "{{ rhel10cis_loopback_firewall_zone }}"
         permanent: true
         state: enabled
         target: ACCEPT
@@ -148,7 +148,7 @@
     - NIST800-53R5_NA
   ansible.posix.firewalld:
     rich_rule: "{{ item }}"
-    zone: "{{ rhel10cis_active_firewall_zone }}"
+    zone: "{{ rhel10cis_loopback_firewall_zone }}"
     permanent: true
     immediate: true
     state: enabled


### PR DESCRIPTION
**Overall Review of Changes:**
Rules 4.1.5 and 4.1.6 must act on the same zone the loopback interface (lo) lives in. 4.1.6 was using `rhel10cis_active_firewall_zone` (the 4.1.4 external zone, target DROP), conflicting with the loopback requirement (target ACCEPT). Added a dedicated `rhel10cis_loopback_firewall_zone` variable (default: `trusted`) and pointed both 4.1.5 and 4.1.6 at it.

**Issue Fixes:**
Fix Nessus non-compliance on control 4.1.6.

**Enhancements:**
Introduced `rhel10cis_loopback_firewall_zone` to decouple the loopback zone (4.1.5/4.1.6) from the active firewall zone (4.1.4).
 
**How has this been tested?:**
Tested and audited using Nessus using 3 RHEL 10 Machines (2 VM, 1 BM Server)