### PR TITLE
fix: add become: true to rule 1.1.1.11 run task

### DIFF
--- a/tasks/section_1/cis_1.1.1.x.yml
+++ b/tasks/section_1/cis_1.1.1.x.yml
@@ -354,6 +354,7 @@
 
     - name: "1.1.1.11 | AUDIT | Ensure unused filesystems kernel modules are not available | Run discovery script"
       ansible.builtin.command: /var/fs_with_cves.sh
+      become: true
       changed_when: false
       failed_when: discovered_fs_modules_loaded.rc not in [ 0, 99 ]
       register: discovered_fs_modules_loaded


### PR DESCRIPTION
Rule 1.1.1.11 deploys /var/fs_with_cves.sh as root (mode u+x,go-wx) but the run task lacks become: true, causing Permission denied. Tested on RHEL 10.1 with 1.0.2 and Ansible 2.17.14.